### PR TITLE
Fix for default values

### DIFF
--- a/base_objects/record_object.py
+++ b/base_objects/record_object.py
@@ -80,10 +80,10 @@ class Record:
             raise ValidationException(email)
 
     def delete_address(self):
-        self.address = None
+        self.address = ''
 
     def delete_birthday(self):
-        self.address = None
+        self.address = ''
 
     def __str__(self):
         phones_str = ', '.join(str(phone) for phone in self.phones)

--- a/base_objects/record_object.py
+++ b/base_objects/record_object.py
@@ -8,8 +8,8 @@ class Record:
         self.name = Name(name)
         self.phones = []
         self.emails = []
-        self.address = None
-        self.birthday = None
+        self.address = ''
+        self.birthday = ''
 
     def add_phone(self, phone):
         new_phone = Phone(phone)


### PR DESCRIPTION
https://trello.com/c/JJSFlPs0/69-incorrect-validation-for-all-empty-fields-in-method-addcontact

validation will not be run if user gives empty string:
```
        if address:
            record.add_address(address)
```

`add_address` is not run and validation is not run.
‌